### PR TITLE
Simplify force implementation.

### DIFF
--- a/sailfish/sym.py
+++ b/sailfish/sym.py
@@ -553,7 +553,7 @@ def accel_vector(grid, grid_num):
 
 def free_energy_external_force(sim, grid_num=0):
     grid = sim.grid
-    # TODO: verify is this needs to be an accel or force vector;
+    # TODO: verify if this needs to be an accel or force vector;
     # add references
     ea = accel_vector(grid, grid_num)
     ret = []
@@ -608,21 +608,17 @@ def bgk_external_force(grid, grid_num=0):
     """
     pref = Symbol('pref')
 
-    # FIXME: this is misguiding, as it is actually a force vector, not an accel
-    # vector
     ea = accel_vector(grid, grid_num)
     ret = []
 
     for i, ei in enumerate(grid.basis):
-        t = pref * grid.weights[i] * poly_factorize( (ei - grid.v + ei.dot(grid.v)*ei*3).dot(ea))
+        t = pref * grid.weights[i] * poly_factorize((ei - grid.v + ei.dot(grid.v)*ei*3).dot(ea))
         ret.append((t, grid.idx_name[i]))
 
     return ret
 
 def bgk_external_force_pref(grid_num=0):
     # FIXME: This includes a factor of c_s^2.
-
-    # FIXME
     rho = getattr(S, 'g%sm0' % grid_num)
 
     if grid_num == 0:
@@ -630,7 +626,9 @@ def bgk_external_force_pref(grid_num=0):
     else:
         rho = 'phi'
 
-    return '%s * (3.0f - 3.0f/(2.0f * tau%s))' % (rho, grid_num)
+    # This includes a density factor as the device code always computes
+    # accelerations, not forces.
+    return '%s * 3.0f * (1.0f - 1.0f/(2.0f * tau%s))' % (rho, grid_num)
 
 def bb_swap_pairs(grid):
     """Get a set of indices which have to be swapped for a full bounce-back."""

--- a/sailfish/templates/shan_chen.mako
+++ b/sailfish/templates/shan_chen.mako
@@ -15,8 +15,7 @@
 
 	if (!isWallNode(type)) {
 		%for dists, coupling_const in force_couplings.iteritems():
-
-			// Interaction between two components.
+			// Interaction force between two components.
 			%if dists[0] != dists[1]:
 				%if dim == 2:
 					shan_chen_force(gi, gg${dists[0]}m0, gg${dists[1]}m0,
@@ -25,12 +24,12 @@
 					shan_chen_force(gi, gg${dists[0]}m0, gg${dists[1]}m0,
 						${coupling_const}, sca${dists[0]}, sca${dists[1]}, gx, gy, gz);
 				%endif
-			// Self-interaction of a single component.
+			// Self-interaction force of a single component.
 			%else:
 				%if dim == 2:
-					shan_chen_accel_self(gi, gg${dists[0]}m0, ${coupling_const}, sca${dists[0]}, gx, gy);
+					shan_chen_force_self(gi, gg${dists[0]}m0, ${coupling_const}, sca${dists[0]}, gx, gy);
 				%else:
-					shan_chen_accel_self(gi, gg${dists[0]}m0, ${coupling_const}, sca${dists[0]}, gx, gy, gz);
+					shan_chen_force_self(gi, gg${dists[0]}m0, ${coupling_const}, sca${dists[0]}, gx, gy, gz);
 				%endif
 			%endif
 		%endfor
@@ -70,7 +69,7 @@ ${device_func} inline float sc_ppot(${global_ptr} float *field, int gi)
 
 // Calculates the Shan-Chen force between a single fluid component (self-interaction).
 // The form of the interaction is the same as that of a force between two components (see below).
-${device_func} inline void shan_chen_accel_self(int i, ${global_ptr} float *f1,
+${device_func} inline void shan_chen_force_self(int i, ${global_ptr} float *f1,
 		float cc, float *a1, int x, int y
 %if dim == 3:
 	, int z


### PR DESCRIPTION
For consistency, we always compute an acceleration vector on the compute
device, and only transform it into a force vector in the code that
modifies the mass fractions (by having density in the force prefactor).

This commit also fixes a bug which caused the force implementation to
use a spurious 'rho' factor in non-Shan-Chen simulations.
