### PR TITLE
Add an overridable function run after the simulation step.

### DIFF
--- a/sailfish/lb_base.py
+++ b/sailfish/lb_base.py
@@ -96,8 +96,18 @@ class LBSim(object):
         self.iteration = 0
 
     def need_output(self):
+        """Returns True when data for macroscopic fields is necessary
+        for the current iteration, based on command line parameters
+        --from --every.
+        It is used in subdomain_runner.py:main loop.
+        """
         return ((self.iteration + 1) % self.config.every) == 0 and self.config.from_ <= (self.iteration)
+
     def after_step(self):
+        """ This function is called in main loop of
+        subdomain_runner.py after each step. 
+        It replaces functionality of hooks in v0.2
+        """
         pass
 
     # TODO(michalj): Restore support for defining visualization fields.

--- a/sailfish/subdomain_runner.py
+++ b/sailfish/subdomain_runner.py
@@ -1275,6 +1275,7 @@ class BlockRunner(object):
             self._profile.end_step()
 
             self._sim.after_step()
+
         # Receive any data from remote nodes prior to termination.  This ensures
         # we don't run into problems with zmq.
         self._data_stream.synchronize()


### PR DESCRIPTION
def after_step(self):
x=1.123
for i in range(N):
    x=x+2.1*x

causes visible slow down in simulation ldc_2d, 128x128 for N~1000
For N=100 it seems to be negligible 

benchmark tests of clean example:  
./examples/ldc_2d.py --mode=benchmark --every=100 --max_iters=1000 --lat_nx=2048 --lat_ny=2048
./examples/ldc_2d.py --mode=benchmark --every=100 --max_iters=1000

Before
Total MLUPS: eff:822.65  comp:862.04
Total MLUPS: eff:239.87  comp:421.40

After
Total MLUPS: eff:828.56  comp:863.44
Total MLUPS: eff:235.38  comp:415.61

Note that results  vary by few percent from run to run.
