### PR TITLE
fix has_symbol() conditional

### DIFF
--- a/sailfish/node_type.py
+++ b/sailfish/node_type.py
@@ -470,7 +470,7 @@ class DynamicValue(object):
         depends on at least one of the symbols provided as arguments."""
         for symbol in args:
             for param in self.params:
-                if isinstance(param, expr.Expr) and symbol in param:
+                if isinstance(param, expr.Expr) and symbol in param.free_symbols:
                     return True
         return False
 


### PR DESCRIPTION
Ran into a problem on Windows where `symbol in param` returns a
"TypeError: argument of type 'Mul' is not iterable". Fixed by calling
the `free_symbols` attribute on `param` which returns a set of symbols.
This should work on any platform.
