### PR TITLE
Resolved python 3.7 'async' keyword problem

### DIFF
--- a/sailfish/lb_base.py
+++ b/sailfish/lb_base.py
@@ -152,12 +152,12 @@ class LBSim(object):
         for src in sources:
             for field in src.fields():
                 if type(field) is ScalarField:
-                    f, _ = runner.make_scalar_field(name=field.name, async=True,
+                    f, _ = runner.make_scalar_field(name=field.name, asynchronous=True,
                                                     gpu_array=field.gpu_array)
                     f[:] = field.init
                     self._scalar_fields.append(FieldPair(field, f))
                 elif type(field) is VectorField:
-                    f = runner.make_vector_field(name=field.name, async=True,
+                    f = runner.make_vector_field(name=field.name, asynchronous=True,
                                                  gpu_array=field.gpu_array)
                     self._vector_fields.append(FieldPair(field, f))
                     for i in range(0, self.grid.dim):

--- a/sailfish/subdomain_runner.py
+++ b/sailfish/subdomain_runner.py
@@ -22,6 +22,7 @@ from sailfish import codegen, io
 from sailfish.lb_base import LBMixIn, LBSim
 from sailfish.profile import profile, TimeProfile
 from sailfish.subdomain_connection import ConnectionBuffer, MacroConnectionBuffer
+from sailfish.util import deprecated_async
 import sailfish.node_type as nt
 from functools import reduce
 
@@ -250,8 +251,9 @@ class SubdomainRunner(object):
     def add_visualization_field(self, field_cb, name):
         self._output.register_field(field_cb, name, visualization=True)
 
+    @deprecated_async
     def make_scalar_field(self, dtype=None, name=None, register=True,
-                          async=False, gpu_array=False, need_indirect=True,
+                          asynchronous=False, gpu_array=False, need_indirect=True,
                           nonghost_view=True):
         """Allocates a scalar NumPy array.
 
@@ -270,7 +272,7 @@ class SubdomainRunner(object):
         if dtype is None:
             dtype = self.float
 
-        if async:
+        if asynchronous:
             field = self.backend.alloc_async_host_buf(self._physical_size, dtype=dtype)
         else:
             field = np.zeros(self._physical_size, dtype=dtype)
@@ -309,7 +311,7 @@ class SubdomainRunner(object):
         # initialization code.
         sparse_field = None
         if self.config.node_addressing == 'indirect' and need_indirect:
-            if async:
+            if asynchronous:
                 sparse_field = self.backend.alloc_async_host_buf(
                     self._subdomain.active_nodes, dtype=dtype)
             else:
@@ -322,7 +324,8 @@ class SubdomainRunner(object):
     def field_base(self, field):
         return self._field_base[id(field.base)]
 
-    def make_vector_field(self, name=None, output=False, async=False,
+    @deprecated_async
+    def make_vector_field(self, name=None, output=False, asynchronous=False,
                           gpu_array=False):
         """Allocates several scalar arrays representing a vector field."""
         components = []
@@ -330,7 +333,7 @@ class SubdomainRunner(object):
 
         for x in range(0, self._spec.dim):
             field, sparse_field = self.make_scalar_field(
-                self.float, register=False, async=async, gpu_array=gpu_array)
+                self.float, register=False, asynchronous=asynchronous, gpu_array=gpu_array)
             components.append(field)
             sparse_components.append(sparse_field)
 

--- a/sailfish/util.py
+++ b/sailfish/util.py
@@ -11,6 +11,7 @@ import logging
 import random
 import socket
 import sys
+from functools import wraps
 
 import numpy as np
 from math import exp, log, ceil
@@ -324,3 +325,18 @@ def load_array(fname):
         return np.load(gzip.GzipFile(fname))
     else:
         return np.load(fname)
+
+
+def deprecated_async(func):
+    """A decorator allows use 'async' function parameter name, but deprecate it"""
+    @wraps(func)
+    def inner(*args, **kwargs):
+        if 'async' in kwargs:
+            if 'asynchronous' in kwargs:
+                raise ValueError('cannot use both async and asynchronous '
+                                 'keyword arguments! the latter obsoletes the first.')
+            warnings.warn('async keyword argumnt is deprecated, '
+                          'use asynchronous instead', DeprecationWarning)
+            kwargs['asynchronous'] = kwargs.pop('async')
+        return func(*args, **kwargs)
+    return inner

--- a/tests/sim.py
+++ b/tests/sim.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 
 from sailfish import lb_base
+from sailfish.util import deprecated_async
 
 class SimTest(lb_base.LBSim):
     @classmethod
@@ -9,8 +10,9 @@ class SimTest(lb_base.LBSim):
         return [lb_base.ScalarField('a'), lb_base.ScalarField('b')]
 
 class DummyRunner(object):
+    @deprecated_async
     def make_scalar_field(self, dtype=None, name=None, register=True,
-            async=False, gpu_array=False):
+            asynchronous=False, gpu_array=False):
         if dtype is None:
             dtype = np.float
         buf = np.zeros([64, 64], dtype=dtype)


### PR DESCRIPTION
In python 3.7, 'async' is a reserved keyword
Changing function parameters name from 'asyn' to 'asynchronous'
Added a decorator, that let keep old API, but deprecate it